### PR TITLE
SA 190/classify for SOC - Change port number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean: ## Clean the temporary files.
 	rm -rf .ruff_cache	
 
 # Make does not like interpreting : in the target name, so we use a variable
-API_CMD=poetry run uvicorn soc_classification_vector_store.api.main:app --host 0.0.0.0 --port 8088 --reload
+API_CMD=poetry run uvicorn soc_classification_vector_store.api.main:app --host 0.0.0.0 --port 8089 --reload
 
 .PHONY: run-vector-store
 run-vector-store: ## Run the vectore store and API
@@ -77,7 +77,7 @@ docker-image: ## Build the Docker image
 
 .PHONY: run-docker-image
 run-docker-image: ## Run the Docker image
-	docker run -p 8088:8088 vector-store
+	docker run -p 8089:8089 vector-store
 
 .PHONY: docker-clean
 docker-clean: ## Clean Docker resources


### PR DESCRIPTION
…tore port

# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Port number needs changing in order for both the sic and soc vector stores to run simultaneously when debugging.

For https://github.com/ONSdigital/survey-assist-api/pull/16

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [X] Refactor in new port number to run on port 8089 in `Makefile`

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Confirm the soc vector store runs in local host port 8089

```
make run-vector-store
```
or

```
make run-docker-image
```
